### PR TITLE
Simplify SmoothLookAt 3D by not constructing a new transform

### DIFF
--- a/smoothlookat3d.gd
+++ b/smoothlookat3d.gd
@@ -13,7 +13,7 @@
 tool
 
 static func SmoothLookAt( nodeToTurn, targetPosition, turnSpeed ):
-	var transf = Transform(Basis(), nodeToTurn.global_transform.origin).looking_at(targetPosition, Vector3.UP)
+	var transf = nodeToTurn.global_transform.looking_at(targetPosition, Vector3.UP)
 	nodeToTurn.global_transform = nodeToTurn.global_transform.interpolate_with(transf, turnSpeed)
 
 static func SmoothLookAtRigid( nodeToTurn, targetPosition, turnSpeed, oriented = true ):


### PR DESCRIPTION
It was very silly of me to construct a new transform when we could just use the old one directly. @LillyByte 